### PR TITLE
Enable BuildKit cache for Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Ignore files and directories not needed for the image build
+.git
+.github
+.docker-cache
+persistent_storage
+docs

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 .env
 persistent_storage/*
 .vscode/
+.docker-cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.5
 # SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
@@ -20,12 +21,12 @@ WORKDIR /app
 
 # Install dependencies
 ADD dockerfile_scripts/install_deps.sh dockerfile_scripts/install_deps.sh
-RUN ./dockerfile_scripts/install_deps.sh
+RUN --mount=type=cache,target=/var/lib/apt/lists --mount=type=cache,target=/var/cache/apt ./dockerfile_scripts/install_deps.sh
 ADD dockerfile_scripts/install_py11.sh dockerfile_scripts/install_py11.sh
-RUN ./dockerfile_scripts/install_py11.sh
+RUN --mount=type=cache,target=/var/lib/apt/lists --mount=type=cache,target=/var/cache/apt ./dockerfile_scripts/install_py11.sh
 ADD dockerfile_scripts/pgsql dockerfile_scripts/pgsql
-RUN ./dockerfile_scripts/pgsql/install.sh
-RUN apt-get autoclean
+RUN --mount=type=cache,target=/var/lib/apt/lists --mount=type=cache,target=/var/cache/apt ./dockerfile_scripts/pgsql/install.sh
+RUN --mount=type=cache,target=/var/lib/apt/lists --mount=type=cache,target=/var/cache/apt apt-get autoclean
 ADD dockerfile_scripts/entrypoint.sh dockerfile_scripts/entrypoint.sh
 
 # Restore interactivity
@@ -35,10 +36,10 @@ ENV DEBIAN_FRONTEND dialog
 COPY requirements.txt .
 
 # Install requirements
-RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel
-RUN python3 -m pip install --no-cache-dir https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.13-cu122/llama_cpp_python-0.3.13-cp311-cp311-linux_x86_64.whl
+RUN --mount=type=cache,target=/root/.cache/pip python3 -m pip install --upgrade pip setuptools wheel
+RUN --mount=type=cache,target=/root/.cache/pip python3 -m pip install https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.13-cu122/llama_cpp_python-0.3.13-cp311-cp311-linux_x86_64.whl
 RUN sed -i '/llama_cpp_python/d' requirements.txt
-RUN python3 -m pip install --no-cache-dir -r requirements.txt && python3 -m pip cache purge
+RUN --mount=type=cache,target=/root/.cache/pip python3 -m pip install -r requirements.txt
 
 # Copy application files
 COPY context_chat_backend context_chat_backend

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,13 @@ version: '3.9'
 
 services:
   ccbe:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
+      cache_from:
+        - type=local,src=.docker-cache
+      cache_to:
+        - type=local,dest=.docker-cache,mode=max
     env_file: .env
     ports:
       - "10034:10034"


### PR DESCRIPTION
## Summary
- Enable BuildKit features in Dockerfile and cache apt/pip downloads with build-time mounts for faster rebuilds.
- Configure Compose build to persist BuildKit cache locally and ignore cache directories.
- Ignore BuildKit cache directory in version control and build contexts.

## Testing
- `pre-commit run --files Dockerfile docker-compose.yaml .gitignore .dockerignore`
- `DOCKER_BUILDKIT=1 docker build -t ccbe-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_6899d3279ce0832ab2ea428847dc6888