### PR TITLE
Add startup document lifecycle test

### DIFF
--- a/context_chat_backend/startup_tests.py
+++ b/context_chat_backend/startup_tests.py
@@ -1,0 +1,102 @@
+import asyncio
+import logging
+from io import BytesIO
+from typing import Iterable
+
+import httpx
+
+logger = logging.getLogger("ccb.startup_test")
+
+
+async def _document_lifecycle(base_url: str, client: httpx.AsyncClient) -> None:
+    """End-to-end test: upload -> search -> delete -> verify deletion."""
+    user_id = "startup-test-user"
+    filename = "startup-test.txt"
+    content = b"hello world"
+    headers = {
+        "userIds": user_id,
+        "title": filename,
+        "type": "text/plain",
+        "modified": "1",
+        "provider": "startup-test",
+    }
+
+    files = {"sources": (filename, BytesIO(content), "text/plain", headers)}
+    try:
+        resp = await client.put(f"{base_url}/loadSources", files=files)
+    except Exception as e:  # pragma: no cover - network issues
+        logger.error("PUT /loadSources failed", exc_info=e)
+        return
+    if resp.status_code != 200:
+        logger.error("PUT /loadSources failed", extra={"status": resp.status_code, "body": resp.text})
+        return
+    loaded = resp.json().get("loaded_sources", [])
+    if not loaded:
+        logger.error("PUT /loadSources did not return source ids", extra={"response": resp.text})
+        return
+    source_id = loaded[0]
+    logger.info("Loaded test document", extra={"source_id": source_id})
+
+    query_payload = {"userId": user_id, "query": "hello", "useContext": True}
+    resp = await client.post(f"{base_url}/docSearch", json=query_payload)
+    if resp.status_code == 200 and resp.json():
+        logger.info("docSearch returned results", extra={"hits": len(resp.json())})
+    else:
+        logger.error(
+            "docSearch failed to return results",
+            extra={"status": resp.status_code, "body": resp.text},
+        )
+
+    resp = await client.post(f"{base_url}/deleteSources", json={"sourceIds": [source_id]})
+    if resp.status_code == 200:
+        logger.info("deleteSources succeeded")
+    else:
+        logger.error(
+            "deleteSources failed", extra={"status": resp.status_code, "body": resp.text}
+        )
+
+    resp = await client.post(f"{base_url}/docSearch", json=query_payload)
+    if resp.status_code == 200 and not resp.json():
+        logger.info("Deletion verified: no results returned")
+    else:
+        logger.error(
+            "Deletion verification failed",
+            extra={"status": resp.status_code, "body": resp.text},
+        )
+
+
+async def _check_route(client: httpx.AsyncClient, method: str, url: str) -> None:
+    try:
+        resp = await client.request(method, url)
+        logger.info(
+            "Checked route",
+            extra={"method": method, "url": url, "status": resp.status_code},
+        )
+    except Exception as e:  # pragma: no cover - network issues
+        logger.error(
+            "Route check failed",
+            extra={"method": method, "url": url, "error": str(e)},
+        )
+
+
+async def _per_route_checks(base_url: str, client: httpx.AsyncClient) -> None:
+    routes: Iterable[tuple[str, str]] = [
+        ("GET", f"{base_url}/"),
+        ("GET", f"{base_url}/enabled"),
+        ("POST", f"{base_url}/countIndexedDocuments"),
+    ]
+    for method, url in routes:
+        await _check_route(client, method, url)
+
+
+async def run_startup_tests(base_url: str) -> None:
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            await _document_lifecycle(base_url, client)
+        except Exception as e:  # pragma: no cover - network issues
+            logger.error("Document lifecycle test failed", exc_info=e)
+        await _per_route_checks(base_url, client)
+
+
+if __name__ == "__main__":
+    asyncio.run(run_startup_tests("http://localhost:9000"))


### PR DESCRIPTION
## Summary
- add startup document lifecycle test that uploads, queries and deletes a test document
- log success/failure to `ccb.startup_test`
- run existing route checks even if lifecycle test fails

## Testing
- `python -m py_compile context_chat_backend/startup_tests.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1c5115930832a8724fb75fe8adae7