### PR TITLE
Skip PostgreSQL startup for R2R backend

### DIFF
--- a/dockerfile_scripts/entrypoint.sh
+++ b/dockerfile_scripts/entrypoint.sh
@@ -6,9 +6,14 @@
 set -e
 
 source /etc/environment;
-"$(dirname $(realpath $0))/pgsql/setup.sh";
-source /etc/environment;
+
+if [ -z "${RAG_BACKEND}" ] || [ "${RAG_BACKEND,,}" = "builtin" ]; then
+    "$(dirname $(realpath $0))/pgsql/setup.sh";
+    source /etc/environment;
+fi
 
 python3 -u ./main.py;
 
-"$(dirname $(realpath $0))/pgsql/setup.sh" stop
+if [ -z "${RAG_BACKEND}" ] || [ "${RAG_BACKEND,,}" = "builtin" ]; then
+    "$(dirname $(realpath $0))/pgsql/setup.sh" stop
+fi


### PR DESCRIPTION
## Summary
- Avoid starting and stopping the local PostgreSQL service when the RAG backend is not builtin (e.g. when using R2R)

## Testing
- `python -m pre_commit run --files dockerfile_scripts/entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a32720a098832a80dd5332301ff503