### PR TITLE
feat: support R2R API key

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -234,6 +234,7 @@ RAG_BACKEND=builtin           # default; set to r2r|pinecone|supabase to switch
 
 # R2R
 R2R_BASE_URL=http://127.0.0.1:7272
+R2R_API_KEY=            # sent as X-API-Key
 R2R_API_TOKEN=
 
 # Pinecone (scaffold)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ RAG_BACKEND=builtin
 # Optional: R2R Graph RAG
 # RAG_BACKEND=r2r
 # R2R_BASE_URL=http://127.0.0.1:7272
-# R2R_API_TOKEN=your_token_here
+# R2R_API_KEY=your_api_key_here  # sent as X-API-Key
+# R2R_API_TOKEN=your_token_here  # optional bearer token
 
 # Optional: Pinecone (scaffold)
 # RAG_BACKEND=pinecone
@@ -48,7 +49,8 @@ RAG_BACKEND=builtin
 ```
 
 * **`builtin` (default):** exact upstream behavior; no code path changes.
-* **`r2r`:** uses an external **R2R** server. Make sure `R2R_BASE_URL` is reachable from CCBE.
+* **`r2r`:** uses an external **R2R** server. Make sure `R2R_BASE_URL` is reachable from CCBE. If authentication is required,
+  set `R2R_API_KEY` (sent as `X-API-Key`) and/or `R2R_API_TOKEN` (bearer token).
 * **`pinecone` / `supabase`:** scaffolds included; selecting them returns HTTP `501` until implemented.
 
 > Endpoint paths, request/response shapes, and status codes remain identical for all backends.
@@ -63,6 +65,7 @@ RAG_BACKEND=builtin
    ```bash
    RAG_BACKEND=r2r
    R2R_BASE_URL=http://127.0.0.1:7272
+   # R2R_API_KEY=your_api_key_here  # sent as X-API-Key
    # R2R_API_TOKEN=your_token_here
    ```
 3. Start CCBE. On `/init`, the backend verifies connectivity.

--- a/context_chat_backend/backends/r2r.py
+++ b/context_chat_backend/backends/r2r.py
@@ -4,8 +4,8 @@ This backend communicates with an external R2R service over the network
 instead of relying on the optional :mod:`r2r` Python package.  The service
 base URL is taken from the ``R2R_BASE_URL`` environment variable and defaults
 to ``http://127.0.0.1:7272``.  If the target instance requires authentication,
-set ``R2R_API_TOKEN`` to a bearer token so all requests include an
-``Authorization`` header.
+set ``R2R_API_KEY`` to an API key (sent as ``X-API-Key``) and/or
+``R2R_API_TOKEN`` to a bearer token (``Authorization: Bearer …``).
 
 Only a minimal subset of the R2R API is implemented - enough for the Context
 Chat backend to manage collections, documents and to perform search queries.
@@ -29,7 +29,12 @@ class R2RBackend(RagBackend):
     def __init__(self) -> None:
         base = os.getenv("R2R_BASE_URL", "http://127.0.0.1:7272").rstrip("/")
         token = os.getenv("R2R_API_TOKEN")
-        headers = {"Authorization": f"Bearer {token}"} if token else {}
+        api_key = os.getenv("R2R_API_KEY")
+        headers: dict[str, str] = {}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        if api_key:
+            headers["X-API-Key"] = api_key
         self._client = httpx.Client(base_url=base, timeout=30.0, headers=headers)
         # fail fast - used by the /init job as well
         resp = self._client.get("/v3/system/settings")

--- a/example.env
+++ b/example.env
@@ -33,8 +33,9 @@ RAG_BACKEND=r2r
 # Example: http://r2r:7272 when R2R runs as a Docker service on the same network.
 R2R_BASE_URL=http://127.0.0.1:7272
 
-# Optional bearer token for authenticated R2R instances
-# R2R_API_TOKEN=your_token_here
+# Optional credentials for authenticated R2R instances
+# R2R_API_KEY=your_api_key_here       # sent as X-API-Key
+# R2R_API_TOKEN=your_token_here       # sent as Authorization: Bearer
 
 
 # CUDA Support


### PR DESCRIPTION
## Summary
- add `R2R_API_KEY` support and send it via `X-API-Key`
- document new environment variable and header usage

## Testing
- `pre-commit run --files PRD.md README.md context_chat_backend/backends/r2r.py example.env`

------
https://chatgpt.com/codex/tasks/task_e_68a372b2fe28832abf67fe6045ed0045