### PR TITLE
Use health endpoint for R2R connectivity check

### DIFF
--- a/context_chat_backend/backends/r2r.py
+++ b/context_chat_backend/backends/r2r.py
@@ -36,8 +36,10 @@ class R2RBackend(RagBackend):
         if api_key:
             headers["X-API-Key"] = api_key
         self._client = httpx.Client(base_url=base, timeout=30.0, headers=headers)
-        # fail fast - used by the /init job as well
-        resp = self._client.get("/v3/system/settings")
+        # fail fast - used by the /init job as well.  The settings endpoint
+        # requires elevated permissions, so use the public health check
+        # instead to verify connectivity.
+        resp = self._client.get("/v3/health")
         resp.raise_for_status()
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- avoid startup 403s by checking `/v3/health` instead of `/v3/system/settings`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a382178e88832abe9139a75f6df1ce