### PR TITLE
Run R2R startup tests and skip builtin models

### DIFF
--- a/context_chat_backend/startup_tests.py
+++ b/context_chat_backend/startup_tests.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
+from collections.abc import Iterable
 from io import BytesIO
-from typing import Iterable
 
 import httpx
 


### PR DESCRIPTION
## Summary
- skip downloading embedding/tokenizer models and vector DB initialization unless using builtin RAG backend
- run document lifecycle startup test against R2R instance
- delegate search and delete endpoints to R2R and mark unsupported operations

## Testing
- `ruff check context_chat_backend/controller.py context_chat_backend/startup_tests.py`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a38bf92e88832a957142200a40b9f3