### PR TITLE
Align R2R interface and conditional embedder startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ ADD dockerfile_scripts/pgsql dockerfile_scripts/pgsql
 RUN --mount=type=cache,target=/var/lib/apt/lists --mount=type=cache,target=/var/cache/apt ./dockerfile_scripts/pgsql/install.sh
 RUN --mount=type=cache,target=/var/lib/apt/lists --mount=type=cache,target=/var/cache/apt apt-get autoclean
 ADD dockerfile_scripts/entrypoint.sh dockerfile_scripts/entrypoint.sh
+ADD dockerfile_scripts/run_embedding.sh dockerfile_scripts/run_embedding.sh
 
 # Restore interactivity
 ENV DEBIAN_FRONTEND dialog

--- a/dockerfile_scripts/run_embedding.sh
+++ b/dockerfile_scripts/run_embedding.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Conditional launcher for the embedding server. The separate process should
+# only be started when the builtin backend is selected.
+if [ -z "${RAG_BACKEND}" ] || [ "${RAG_BACKEND,,}" = "builtin" ]; then
+    exec python3 -u /app/main_em.py
+else
+    # Keep the supervisor slot occupied without starting the embedder.
+    exec tail -f /dev/null
+fi

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -34,4 +34,4 @@ autostart=true
 autorestart=unexpected
 startsecs=120
 directory=/app
-command=python3 -u /app/main_em.py
+command=/app/dockerfile_scripts/run_embedding.sh


### PR DESCRIPTION
## Summary
- use `/v3/system/status` and `/v3/retrieval/search` in R2R backend
- skip document lifecycle test when app is disabled
- start embedder process only when builtin backend is selected

## Testing
- `pre-commit run --files context_chat_backend/backends/r2r.py context_chat_backend/startup_tests.py dockerfile_scripts/run_embedding.sh supervisord.conf Dockerfile`

------
https://chatgpt.com/codex/tasks/task_e_68a477267fcc832a9035f7ba3aea8afc