### PR TITLE
Ensure R2R backend plugs in with API auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS instructions
+
+- Begin each task by reviewing [PRD.md](PRD.md) and [r2rdocs.txt](r2rdocs.txt) in the repository root. They describe the pluggable RAG architecture and R2R API.
+- Keep CCBE endpoints stable; backend swaps must be controlled via `RAG_BACKEND` environment variable.
+- Prefer small, focused commits with clear messages.
+- Before committing, run `pre-commit run --files <files>` for any touched files and ensure `ruff`, `pyright`, and `pytest` succeed.
+- Ensure all R2R HTTP calls include the proper `X-API-Key` or Bearer token as documented in `r2rdocs.txt`.


### PR DESCRIPTION
## Summary
- add httpx.Auth helper so every R2R request carries X-API-Key/Bearer token
- load RAG backends dynamically via environment flag for easier swapping
- document repository guidelines requiring reading PRD and R2R docs

## Testing
- `pre-commit run --files AGENTS.md main.py context_chat_backend/backends/r2r.py`
- `ruff check context_chat_backend/backends/r2r.py main.py`
- `pyright context_chat_backend/backends/r2r.py main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4a3cdf96c832a95b69ac580326d76