### PR TITLE
Fix R2R backend class naming

### DIFF
--- a/context_chat_backend/backends/r2r.py
+++ b/context_chat_backend/backends/r2r.py
@@ -38,7 +38,7 @@ class _Auth(httpx.Auth):
         yield request
 
 
-class R2RBackend(RagBackend):
+class R2rBackend(RagBackend):
     """Implementation of :class:`RagBackend` that talks to an R2R service."""
 
     def __init__(self) -> None:
@@ -188,3 +188,7 @@ class R2RBackend(RagBackend):
                 }
             )
         return out
+
+
+# Backwards compatibility for earlier imports
+R2RBackend = R2rBackend


### PR DESCRIPTION
## Summary
- ensure `R2rBackend` class exists so `RAG_BACKEND=r2r` loads
- keep `R2RBackend` alias for backward compatibility

## Testing
- `pre-commit run --files context_chat_backend/backends/r2r.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4af7fa334832a88e8cdcbcdbf9a18