### PR TITLE
Log R2R curl commands for startup debugging

### DIFF
--- a/context_chat_backend/backends/r2r.py
+++ b/context_chat_backend/backends/r2r.py
@@ -14,13 +14,17 @@ Chat backend to manage collections, documents and to perform search queries.
 from __future__ import annotations
 
 import json
+import logging
 import os
+import shlex
 from collections.abc import Mapping, Sequence
 from typing import Any
 
 import httpx
 
 from .base import RagBackend
+
+logger = logging.getLogger(__name__)
 
 class R2rBackend(RagBackend):
     """Implementation of :class:`RagBackend` that talks to an R2R service."""
@@ -35,6 +39,17 @@ class R2rBackend(RagBackend):
         if token:
             headers["Authorization"] = f"Bearer {token}"
         self._client = httpx.Client(base_url=base, timeout=30.0, headers=headers)
+
+        # Echo the curl command for lifecycle checks and easier debugging.
+        curl_parts = ["curl", "-i"]
+        for key, value in headers.items():
+            curl_parts.extend(["-H", f"{key}: {value}"])
+        curl_parts.append(f"{base}/v3/system/status")
+        logger.info(
+            "R2R healthcheck command: %s",
+            " ".join(shlex.quote(part) for part in curl_parts),
+        )
+
         # Fail fast - used by the /init job as well. ``/v3/system/status`` is a
         # public endpoint that does not require special permissions and is the
         # recommended way to verify service availability.
@@ -44,7 +59,17 @@ class R2rBackend(RagBackend):
     # ------------------------------------------------------------------
     # Utility helpers
     def _request(self, method: str, path: str, **kwargs) -> dict[str, Any]:
-        resp = self._client.request(method, f"/v3/{path.lstrip('/')}", **kwargs)
+        url_path = f"/v3/{path.lstrip('/')}"
+        curl_parts = ["curl", "-i", "-X", method.upper()]
+        for key, value in self._client.headers.items():
+            curl_parts.extend(["-H", f"{key}: {value}"])
+        curl_parts.append(f"{self._client.base_url}{url_path}")
+        logger.info(
+            "R2R request: %s",
+            " ".join(shlex.quote(part) for part in curl_parts),
+        )
+
+        resp = self._client.request(method, url_path, **kwargs)
         resp.raise_for_status()
         return resp.json() if resp.content else {}
 


### PR DESCRIPTION
## Summary
- Log the curl command used for R2R health checks, including Authorization and X-API-Key headers.
- Echo curl-style request lines for all R2R requests to aid lifecycle tests.

## Testing
- `pre-commit run --files context_chat_backend/backends/r2r.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4bde59464832a95472f634679d360