### PR TITLE
Document CCBE-R2R endpoint mapping and extend startup lifecycle test

### DIFF
--- a/CCBE-R2R_Endpoint_map.txt
+++ b/CCBE-R2R_Endpoint_map.txt
@@ -1,0 +1,18 @@
+CCBE to R2R Endpoint Mapping
+----------------------------
+CCBE Endpoint -> R2R Endpoint(s)
+GET / -> GET /system/health
+PUT /enabled -> GET /system/health
+GET /enabled -> GET /system/health
+POST /init -> GET /system/status
+POST /updateAccessDeclarative -> POST /collections/{id}/users/{user_id} or DELETE /collections/{id}/users/{user_id}
+POST /updateAccess -> POST /collections/{id}/users/{user_id} or DELETE /collections/{id}/users/{user_id}
+POST /updateAccessProvider -> POST /collections/{id}/documents/{document_id} or DELETE /collections/{id}/documents/{document_id}
+POST /deleteSources -> DELETE /documents/{id}
+POST /deleteProvider -> DELETE /collections/{id}/documents/{document_id}
+POST /deleteUser -> DELETE /users/{id}
+POST /countIndexedDocuments -> GET /documents
+PUT /loadSources -> POST /documents
+POST /query -> POST /retrieval/rag
+POST /docSearch -> POST /retrieval/search
+GET /downloadLogs -> GET /logs/viewer


### PR DESCRIPTION
## Summary
- document mapping from each CCBE endpoint to corresponding R2R endpoint
- expand startup test to exercise document upload, list, update, search, delete with raw request/response logging

## Testing
- `pre-commit run --files context_chat_backend/startup_tests.py CCBE-R2R_Endpoint_map.txt`
- `ruff check context_chat_backend/startup_tests.py`
- `pyright context_chat_backend/startup_tests.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5b96a5c1c832aba783f1e73f819ff