### PR TITLE
Expose startup test logs by lowering stderr level

### DIFF
--- a/logger_config.yaml
+++ b/logger_config.yaml
@@ -29,7 +29,7 @@ formatters:
 handlers:
   stderr:
     class: logging.StreamHandler
-    level: WARNING
+    level: INFO
     formatter: default
     stream: ext://sys.stderr
 


### PR DESCRIPTION
## Summary
- Lower stderr handler log level to INFO so startup tests log curl commands

## Testing
- `pre-commit run --files logger_config.yaml`
- `ruff check .`
- `pyright`
- `pytest`
- Verified CMD/BODY/RESULT log entries from `ccb.startup_test`


------
https://chatgpt.com/codex/tasks/task_e_68a5cb370160832a9c6df471acf5e5be