### PR TITLE
Log backend config and fix startup access test

### DIFF
--- a/context_chat_backend/backends/base.py
+++ b/context_chat_backend/backends/base.py
@@ -43,3 +43,7 @@ class RagBackend:
     ) -> list[dict]:
         """Return ranked chunks with at least: text/page_content, metadata dict."""
         raise NotImplementedError
+
+    def config(self) -> dict[str, Any]:
+        """Return a serialisable snapshot of backend configuration."""
+        return {}

--- a/context_chat_backend/backends/r2r.py
+++ b/context_chat_backend/backends/r2r.py
@@ -33,6 +33,9 @@ class R2rBackend(RagBackend):
         base = os.getenv("R2R_BASE_URL", "http://127.0.0.1:7272").rstrip("/")
         token = os.getenv("R2R_API_TOKEN")
         api_key = os.getenv("R2R_API_KEY")
+        self._base_url = base
+        self._has_token = bool(token)
+        self._has_api_key = bool(api_key)
         headers: dict[str, str] = {}
         if api_key:
             headers["X-API-Key"] = api_key
@@ -246,6 +249,15 @@ class R2rBackend(RagBackend):
                     }
                 )
         return out
+
+    def config(self) -> dict[str, Any]:
+        return {
+            "base_url": self._base_url,
+            "auth": {
+                "api_key": self._has_api_key,
+                "token": self._has_token,
+            },
+        }
 
 
 # Backwards compatibility for earlier imports

--- a/context_chat_backend/startup_tests.py
+++ b/context_chat_backend/startup_tests.py
@@ -161,7 +161,7 @@ async def _document_lifecycle(base_url: str, client: httpx.AsyncClient) -> None:
 
     # update
     update_payload = {
-        "op": "add",
+        "op": "allow",
         "userIds": ["startup-test-user2"],
         "sourceId": source_id,
     }

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
+import json
 import logging
 from importlib import import_module
 from os import getenv
@@ -68,8 +69,12 @@ if __name__ == "__main__":
     setup_logging(logging_config)
     app_config: TConfig = app.extra["CONFIG"]
     _setup_log_levels(app_config.debug)
-
-    print("App config:\n" + app_config.model_dump_json(indent=2), flush=True)
+    backend = app.state.rag_backend
+    rag_backend_kind = (getenv("RAG_BACKEND") or "builtin").lower()
+    backend_config = backend.config() if backend else {}
+    config_out = app_config.model_dump()
+    config_out["rag_backend"] = [rag_backend_kind, backend_config]
+    print("App config:\n" + json.dumps(config_out, indent=2), flush=True)
 
     uv_log_config = uvicorn.config.LOGGING_CONFIG  # pyright: ignore[reportAttributeAccessIssue]
     uv_log_config["formatters"]["json"] = logging_config["formatters"]["json"]


### PR DESCRIPTION
## Summary
- include selected RAG backend configuration in startup config output
- expose backend config via RagBackend base class
- adjust startup self-check to use valid `allow` op for access updates

## Testing
- `pre-commit run --files context_chat_backend/backends/base.py context_chat_backend/backends/r2r.py main.py context_chat_backend/startup_tests.py`
- `ruff check context_chat_backend/backends/base.py context_chat_backend/backends/r2r.py main.py context_chat_backend/startup_tests.py`
- `pyright context_chat_backend/backends/base.py context_chat_backend/backends/r2r.py main.py context_chat_backend/startup_tests.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6caaf0550832ab72d44a65c573a2b