### PR TITLE
Handle unsupported access updates when using R2R

### DIFF
--- a/context_chat_backend/controller.py
+++ b/context_chat_backend/controller.py
@@ -324,11 +324,11 @@ def _(
     if len(userIds) == 0:
         return JSONResponse("Empty list of user ids", 400)
 
-    if not is_valid_source_id(sourceId):
-        return JSONResponse("Invalid source id", 400)
-
     if getattr(request.app.state, "rag_backend", None):
         return JSONResponse("Operation not supported", 501)
+
+    if not is_valid_source_id(sourceId):
+        return JSONResponse("Invalid source id", 400)
 
     exec_in_proc(target=decl_update_access, args=(vectordb_loader, userIds, sourceId))
 
@@ -355,11 +355,11 @@ def _(
     if len(userIds) == 0:
         return JSONResponse("Empty list of user ids", 400)
 
-    if not is_valid_source_id(sourceId):
-        return JSONResponse("Invalid source id", 400)
-
     if getattr(request.app.state, "rag_backend", None):
         return JSONResponse("Operation not supported", 501)
+
+    if not is_valid_source_id(sourceId):
+        return JSONResponse("Invalid source id", 400)
 
     exec_in_proc(target=update_access, args=(vectordb_loader, op, userIds, sourceId))
 
@@ -386,11 +386,11 @@ def _(
     if len(userIds) == 0:
         return JSONResponse("Empty list of user ids", 400)
 
-    if not is_valid_provider_id(providerId):
-        return JSONResponse("Invalid provider id", 400)
-
     if getattr(request.app.state, "rag_backend", None):
         return JSONResponse("Operation not supported", 501)
+
+    if not is_valid_provider_id(providerId):
+        return JSONResponse("Invalid provider id", 400)
 
     exec_in_proc(target=update_access, args=(vectordb_loader, op, userIds, providerId))
 

--- a/main.py
+++ b/main.py
@@ -73,6 +73,9 @@ if __name__ == "__main__":
     rag_backend_kind = (getenv("RAG_BACKEND") or "builtin").lower()
     backend_config = backend.config() if backend else {}
     config_out = app_config.model_dump()
+    if backend:
+        for key in ("vectordb", "embedding", "llm"):
+            config_out.pop(key, None)
     config_out["rag_backend"] = [rag_backend_kind, backend_config]
     print("App config:\n" + json.dumps(config_out, indent=2), flush=True)
 


### PR DESCRIPTION
## Summary
- Avoid mis-leading 400 errors for `/updateAccess*` endpoints by checking for the R2R backend first and returning a 501 response when unsupported
- Filter out built-in backend settings from startup config logging when an external RAG backend is active

## Testing
- `ruff check main.py context_chat_backend/controller.py`
- `pyright main.py context_chat_backend/controller.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'context_chat_backend')*


------
https://chatgpt.com/codex/tasks/task_e_68a6d7c3e278832a8be22c8227d16c9d