### PR TITLE
Support access updates via R2R backend

### DIFF
--- a/context_chat_backend/backends/base.py
+++ b/context_chat_backend/backends/base.py
@@ -1,7 +1,7 @@
 # ruff: noqa: I001
 from __future__ import annotations
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 
 class RagBackend:
@@ -32,6 +32,24 @@ class RagBackend:
     def delete_document(self, document_id: str) -> None:
         raise NotImplementedError
 
+    # --- Access control
+    def update_access(
+        self,
+        op: UpdateAccessOp,
+        user_ids: Sequence[str],
+        document_id: str,
+    ) -> None:
+        """Allow or deny ``user_ids`` access to ``document_id``."""
+        raise NotImplementedError
+
+    def decl_update_access(
+        self,
+        user_ids: Sequence[str],
+        document_id: str,
+    ) -> None:
+        """Set exact ``user_ids`` allowed to access ``document_id``."""
+        raise NotImplementedError
+
     # --- Retrieval
     def search(
         self,
@@ -47,3 +65,7 @@ class RagBackend:
     def config(self) -> dict[str, Any]:
         """Return a serialisable snapshot of backend configuration."""
         return {}
+
+
+if TYPE_CHECKING:
+    from context_chat_backend.vectordb.types import UpdateAccessOp

--- a/context_chat_backend/controller.py
+++ b/context_chat_backend/controller.py
@@ -324,11 +324,17 @@ def _(
     if len(userIds) == 0:
         return JSONResponse("Empty list of user ids", 400)
 
+    backend = getattr(request.app.state, "rag_backend", None)
+    if backend:
+        # Delegate to the external RAG backend when available
+        try:
+            backend.decl_update_access(userIds, sourceId)
+        except NotImplementedError:
+            return JSONResponse("Operation not supported", 501)
+        return JSONResponse("Access updated")
+
     if not is_valid_source_id(sourceId):
         return JSONResponse("Invalid source id", 400)
-
-    if getattr(request.app.state, "rag_backend", None):
-        return JSONResponse("Operation not supported", 501)
 
     exec_in_proc(target=decl_update_access, args=(vectordb_loader, userIds, sourceId))
 
@@ -355,11 +361,17 @@ def _(
     if len(userIds) == 0:
         return JSONResponse("Empty list of user ids", 400)
 
+    backend = getattr(request.app.state, "rag_backend", None)
+    if backend:
+        # Delegate to the external RAG backend when available
+        try:
+            backend.update_access(op, userIds, sourceId)
+        except NotImplementedError:
+            return JSONResponse("Operation not supported", 501)
+        return JSONResponse("Access updated")
+
     if not is_valid_source_id(sourceId):
         return JSONResponse("Invalid source id", 400)
-
-    if getattr(request.app.state, "rag_backend", None):
-        return JSONResponse("Operation not supported", 501)
 
     exec_in_proc(target=update_access, args=(vectordb_loader, op, userIds, sourceId))
 
@@ -386,11 +398,11 @@ def _(
     if len(userIds) == 0:
         return JSONResponse("Empty list of user ids", 400)
 
-    if not is_valid_provider_id(providerId):
-        return JSONResponse("Invalid provider id", 400)
-
     if getattr(request.app.state, "rag_backend", None):
         return JSONResponse("Operation not supported", 501)
+
+    if not is_valid_provider_id(providerId):
+        return JSONResponse("Invalid provider id", 400)
 
     exec_in_proc(target=update_access, args=(vectordb_loader, op, userIds, providerId))
 

--- a/main.py
+++ b/main.py
@@ -73,6 +73,10 @@ if __name__ == "__main__":
     rag_backend_kind = (getenv("RAG_BACKEND") or "builtin").lower()
     backend_config = backend.config() if backend else {}
     config_out = app_config.model_dump()
+    if backend:
+        # Omit built-in RAG settings when an external backend is used
+        for key in ("vectordb", "embedding", "llm"):
+            config_out.pop(key, None)
     config_out["rag_backend"] = [rag_backend_kind, backend_config]
     print("App config:\n" + json.dumps(config_out, indent=2), flush=True)
 


### PR DESCRIPTION
## Summary
- delegate access updates to the R2R backend when configured and return 501 if unsupported
- suppress builtin vectordb, embedding, and llm settings from app config when using an external backend

## Testing
- `pre-commit run --files main.py context_chat_backend/controller.py` *(fails: Import "langchain_community.llms.ctranformers" could not be resolved)*
- `ruff check main.py context_chat_backend/controller.py`
- `pyright main.py context_chat_backend/controller.py`
- `PYTHONPATH=. pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d7c3e278832a8be22c8227d16c9d