### PR TITLE
Sanitize source IDs before R2R deletion

### DIFF
--- a/context_chat_backend/controller.py
+++ b/context_chat_backend/controller.py
@@ -43,7 +43,14 @@ from .dyn_loader import LLMModelLoader, VectorDBLoader
 from .models.types import LlmException
 from .ocs_utils import AppAPIAuthMiddleware
 from .setup_functions import ensure_config_file, repair_run, setup_env_vars
-from .utils import JSONResponse, exec_in_proc, is_valid_provider_id, is_valid_source_id, value_of
+from .utils import (
+    JSONResponse,
+    exec_in_proc,
+    is_valid_provider_id,
+    is_valid_source_id,
+    sanitize_source_ids,
+    value_of,
+)
 from .vectordb.service import (
     count_documents_by_provider,
     decl_update_access,
@@ -425,10 +432,10 @@ def _(request: Request, sourceIds: Annotated[list[str], Body(embed=True)]):
         },
     )
 
-    sourceIds = [source.strip() for source in sourceIds if source.strip() != ""]
+    sourceIds = sanitize_source_ids(sourceIds)
 
     if len(sourceIds) == 0:
-        return JSONResponse("No sources provided", 400)
+        return JSONResponse("No valid sources provided", 400)
 
     backend = getattr(request.app.state, "rag_backend", None)
     if backend:

--- a/context_chat_backend/utils.py
+++ b/context_chat_backend/utils.py
@@ -6,7 +6,7 @@ import logging
 import multiprocessing as mp
 import re
 import traceback
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from functools import partial, wraps
 from multiprocessing.connection import Connection
 from time import perf_counter_ns
@@ -100,11 +100,20 @@ def exec_in_proc(group=None, target=None, name=None, args=(), kwargs={}, *, daem
 
 
 def is_valid_source_id(source_id: str) -> bool:
-	return re.match(r'^[a-zA-Z0-9_-]+__[a-zA-Z0-9_-]+: \d+$', source_id) is not None
+        return re.match(r'^[a-zA-Z0-9_-]+__[a-zA-Z0-9_-]+:\s*\d+$', source_id) is not None
 
 
 def is_valid_provider_id(provider_id: str) -> bool:
-	return re.match(r'^[a-zA-Z0-9_-]+__[a-zA-Z0-9_-]+$', provider_id) is not None
+        return re.match(r'^[a-zA-Z0-9_-]+__[a-zA-Z0-9_-]+$', provider_id) is not None
+
+
+def sanitize_source_ids(source_ids: Sequence[str]) -> list[str]:
+        cleaned: list[str] = []
+        for source in source_ids:
+                sid = source.strip().replace(" ", "")
+                if sid and is_valid_source_id(sid):
+                        cleaned.append(sid)
+        return cleaned
 
 
 def timed(func: Callable):

--- a/tests/test_sanitize_source_ids.py
+++ b/tests/test_sanitize_source_ids.py
@@ -1,0 +1,7 @@
+# ruff: noqa: S101
+from context_chat_backend.utils import sanitize_source_ids
+
+
+def test_sanitize_source_ids() -> None:
+    raw = [" files__default: 9013252 ", "invalid", "files__default:9013266"]
+    assert sanitize_source_ids(raw) == ["files__default:9013252", "files__default:9013266"]


### PR DESCRIPTION
## Summary
- sanitize source IDs to drop internal whitespace
- validate IDs and use in deleteSources endpoint
- add unit test for sanitization

## Testing
- `pre-commit run --files context_chat_backend/controller.py context_chat_backend/utils.py tests/test_sanitize_source_ids.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a778ef7c08832a83c492e4596dc48d