### PR TITLE
fix R2R document upload headers

### DIFF
--- a/context_chat_backend/backends/r2r.py
+++ b/context_chat_backend/backends/r2r.py
@@ -197,13 +197,19 @@ class R2rBackend(RagBackend):
                     metadata.get("filename") or os.path.basename(file_path),
                     fh,
                     mime or "application/octet-stream",
-                )
+                ),
+                "metadata": (
+                    None,
+                    json.dumps(metadata),
+                    "application/json",
+                ),
+                "collection_ids": (
+                    None,
+                    json.dumps(list(collection_ids)),
+                    "application/json",
+                ),
             }
-            data = {
-                "metadata": json.dumps(metadata),
-                "collection_ids": json.dumps(list(collection_ids)),
-                "ingestion_mode": "fast",
-            }
+            data = {"ingestion_mode": "fast"}
             created = self._request("POST", "documents", data=data, files=files)
         return created.get("results", {}).get("document_id", "")
 

--- a/context_chat_backend/startup_tests.py
+++ b/context_chat_backend/startup_tests.py
@@ -132,15 +132,16 @@ async def _document_lifecycle(base_url: str, client: httpx.AsyncClient) -> None:
         filename = "startup-test.txt"
         content = b"hello world"
 
+    source_id = "startup-test__default:1"
     headers = {
         "userIds": user_id,
         "title": filename,
         "type": "text/plain",
         "modified": "1",
-        "provider": "startup-test",
+        "provider": source_id.split(":")[0],
     }
 
-    files = {"sources": (filename, BytesIO(content), "text/plain", headers)}
+    files = {"sources": (source_id, BytesIO(content), "text/plain", headers)}
     req_headers: dict[str, str] = {}
     sign_request(req_headers)
 


### PR DESCRIPTION
## Summary
- send R2R document metadata and collection IDs as JSON multipart parts
- give startup test a valid source id for filename validation

## Testing
- `pre-commit run --files context_chat_backend/backends/r2r.py context_chat_backend/startup_tests.py`
- `PYTHONPATH=. pytest` *(fails: async def functions are not natively supported, pytest-asyncio missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a7807de740832a9f21ee268f135d9c