### PR TITLE
fix missing metadata in R2R document uploads

### DIFF
--- a/context_chat_backend/backends/r2r.py
+++ b/context_chat_backend/backends/r2r.py
@@ -204,7 +204,6 @@ class R2rBackend(RagBackend):
                 "collection_ids": json.dumps(list(collection_ids)),
                 "ingestion_mode": "fast",
             }
-            data = {"ingestion_mode": "fast"}
             created = self._request("POST", "documents", data=data, files=files)
         return created.get("results", {}).get("document_id", "")
 

--- a/tests/test_r2r_upsert_document.py
+++ b/tests/test_r2r_upsert_document.py
@@ -1,0 +1,39 @@
+# ruff: noqa: S101
+import json
+
+from context_chat_backend.backends.r2r import R2rBackend
+
+
+def test_upsert_document_sends_metadata_and_collection_ids(tmp_path):
+    backend = R2rBackend.__new__(R2rBackend)
+    backend.find_document_by_title = lambda title: None
+
+    captured = {}
+
+    def fake_request(method, path, data=None, files=None):
+        captured["method"] = method
+        captured["path"] = path
+        captured["data"] = data
+        captured["files"] = files
+        return {"results": {"document_id": "doc1"}}
+
+    backend._request = fake_request  # type: ignore[attr-defined]
+
+    file = tmp_path / "doc.txt"
+    file.write_text("hello")
+
+    metadata = {
+        "title": "doc.txt",
+        "filename": "doc.txt",
+        "modified": "1",
+        "content-length": "5",
+    }
+    collection_ids = ["cid1"]
+
+    doc_id = backend.upsert_document(str(file), metadata, collection_ids)
+
+    assert doc_id == "doc1"
+    assert json.loads(captured["data"]["metadata"]) == metadata
+    assert json.loads(captured["data"]["collection_ids"]) == collection_ids
+    assert captured["data"]["ingestion_mode"] == "fast"
+    assert "file" in captured["files"]


### PR DESCRIPTION
## Summary
- send metadata and collection IDs when uploading documents to R2R
- add regression test to ensure upsert_document forwards metadata and collection IDs

## Testing
- `pre-commit run --files context_chat_backend/backends/r2r.py tests/test_r2r_upsert_document.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a78aea96e8832aa5ddb77b125f4289