### PR TITLE
Fix R2R ingestion content type handling

### DIFF
--- a/context_chat_backend/backends/r2r.py
+++ b/context_chat_backend/backends/r2r.py
@@ -96,6 +96,23 @@ class R2rBackend(RagBackend):
             curl_parts.extend(["-d", payload])
             logger.debug("R2R request payload: %s", payload)
 
+        files_arg = kwargs.get("files")
+        if files_arg:
+            items = files_arg.items() if isinstance(files_arg, dict) else files_arg
+            for key, value in items:
+                if isinstance(value, tuple | list):
+                    filename = value[0] if len(value) > 0 else None
+                    content_type = value[2] if len(value) > 2 else None
+                    if filename is None:
+                        part_val = value[1] if len(value) > 1 else ""
+                        part = f"{key}={part_val}"
+                    else:
+                        ct = f";type={content_type}" if content_type else ""
+                        part = f"{key}=@{filename}{ct}"
+                else:
+                    part = f"{key}={value}"
+                curl_parts.extend(["-F", part])
+
         curl_parts.append(f"{self._client.base_url}{url_path}")
 
         cmd = " ".join(shlex.quote(part) for part in curl_parts)
@@ -189,22 +206,32 @@ class R2rBackend(RagBackend):
             self.delete_document(existing["id"])
 
         with open(file_path, "rb") as fh:
-            mime, _ = mimetypes.guess_type(
-                metadata.get("filename") or os.path.basename(file_path)
-            )
-            files = {
-                "file": (
-                    metadata.get("filename") or os.path.basename(file_path),
-                    fh,
-                    mime or "application/octet-stream",
+            # ``mimetypes.guess_type`` relies on file extensions.  The sanitized
+            # ``metadata['filename']`` often lacks one, so use the temporary file
+            # path (which preserves the original extension) to determine the
+            # content type.  ``metadata`` may optionally include an explicit
+            # ``type``; if guessing fails, fall back to that before using the
+            # generic ``application/octet-stream``.
+            mime, _ = mimetypes.guess_type(os.path.basename(file_path))
+            if not mime:
+                mime = metadata.get("type")
+            files = [
+                (
+                    "file",
+                    (
+                        metadata.get("filename") or os.path.basename(file_path),
+                        fh,
+                        mime or "application/octet-stream",
+                    ),
                 ),
-            }
-            data = {
-                "metadata": json.dumps(metadata),
-                "collection_ids": json.dumps(list(collection_ids)),
-                "ingestion_mode": "fast",
-            }
-            created = self._request("POST", "documents", data=data, files=files)
+                ("metadata", (None, json.dumps(metadata), "application/json")),
+                (
+                    "collection_ids",
+                    (None, json.dumps(list(collection_ids)), "application/json"),
+                ),
+                ("ingestion_mode", (None, "fast")),
+            ]
+            created = self._request("POST", "documents", files=files)
         return created.get("results", {}).get("document_id", "")
 
     def find_document_by_filename(self, filename: str) -> dict | None:

--- a/tests/test_r2r_upsert_document.py
+++ b/tests/test_r2r_upsert_document.py
@@ -33,7 +33,8 @@ def test_upsert_document_sends_metadata_and_collection_ids(tmp_path):
     doc_id = backend.upsert_document(str(file), metadata, collection_ids)
 
     assert doc_id == "doc1"
-    assert json.loads(captured["data"]["metadata"]) == metadata
-    assert json.loads(captured["data"]["collection_ids"]) == collection_ids
-    assert captured["data"]["ingestion_mode"] == "fast"
-    assert "file" in captured["files"]
+    files = dict(captured["files"])
+    assert json.loads(files["metadata"][1]) == metadata
+    assert json.loads(files["collection_ids"][1]) == collection_ids
+    assert files["ingestion_mode"][1] == "fast"
+    assert "file" in files


### PR DESCRIPTION
## Summary
- send R2R document metadata and collection IDs as JSON parts in multipart uploads
- log multipart fields with `-F` for clearer debugging

## Testing
- `pre-commit run --files context_chat_backend/backends/r2r.py tests/test_r2r_upsert_document.py`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a80749b400832aab43a9bf9192a6a1