### PR TITLE
Increase startup test timeout

### DIFF
--- a/context_chat_backend/startup_tests.py
+++ b/context_chat_backend/startup_tests.py
@@ -222,7 +222,7 @@ async def _per_route_checks(base_url: str, client: httpx.AsyncClient) -> None:
 
 
 async def run_startup_tests(base_url: str) -> None:
-    async with httpx.AsyncClient(timeout=10.0) as client:
+    async with httpx.AsyncClient(timeout=60.0) as client:
         headers: dict[str, str] = {}
         sign_request(headers)
         enabled = False


### PR DESCRIPTION
## Summary
- expand httpx AsyncClient timeout to 60s for startup checks

## Testing
- `python -m pre_commit run --files context_chat_backend/startup_tests.py`
- `ruff check context_chat_backend/startup_tests.py`
- `pyright context_chat_backend/startup_tests.py`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac9cd3b3b8832aae737456e6f20cde