### PR TITLE
Log R2R requests with query parameters and map CCBE actions

### DIFF
--- a/context_chat_backend/backends/r2r.py
+++ b/context_chat_backend/backends/r2r.py
@@ -21,6 +21,7 @@ import os
 import shlex
 from collections.abc import Mapping, Sequence
 from typing import Any
+from urllib.parse import urlencode
 
 import httpx
 
@@ -113,7 +114,9 @@ class R2rBackend(RagBackend):
                     part = f"{key}={value}"
                 curl_parts.extend(["-F", part])
 
-        curl_parts.append(f"{self._client.base_url}{url_path}")
+        params = kwargs.get("params")
+        query = f"?{urlencode(params, doseq=True)}" if params else ""
+        curl_parts.append(f"{self._client.base_url}{url_path}{query}")
 
         cmd = " ".join(shlex.quote(part) for part in curl_parts)
         if action:

--- a/docs/ccbe_r2r_mapping.md
+++ b/docs/ccbe_r2r_mapping.md
@@ -1,0 +1,18 @@
+# CCBE to R2R Action Mapping
+
+```mermaid
+graph TD
+    EC[CCBE `ensure_collections`] -->|GET /v3/collections| RC1[(R2R collections list)]
+    EC -->|POST /v3/collections| RC2[(R2R collection create)]
+    LD[CCBE `list_documents`] -->|GET /v3/documents| RD[(R2R documents list)]
+    UD[CCBE `upsert_document`] -->|POST /v3/documents| RU[(R2R document upsert)]
+    DD[CCBE `delete_document`] -->|DELETE /v3/documents/{id}| RDel[(R2R document delete)]
+    SR[CCBE `search`] -->|POST /v3/retrieval/search| RS[(R2R search)]
+```
+
+## References
+- `ensure_collections` performs both list and create operations on R2R collections【F:context_chat_backend/backends/r2r.py†L134-L166】
+- `list_documents` queries the R2R documents endpoint with pagination parameters【F:context_chat_backend/backends/r2r.py†L170-L177】
+- `upsert_document` uploads files and metadata to R2R【F:context_chat_backend/backends/r2r.py†L201-L283】
+- `delete_document` removes a document from R2R by ID【F:context_chat_backend/backends/r2r.py†L296-L301】
+- `search` forwards user queries to R2R's retrieval API【F:context_chat_backend/backends/r2r.py†L363-L379】

--- a/logger_config.yaml
+++ b/logger_config.yaml
@@ -37,7 +37,7 @@ handlers:
     class: logging.handlers.RotatingFileHandler
     level: DEBUG
     formatter: json
-    filename: logs/ccb.log
+    filename: /app/logs/ccb.log
     maxBytes: 20971520
     backupCount: 10
 


### PR DESCRIPTION
## Summary
- include query parameters in R2R curl logging and direct logs to /app/logs
- document CCBE to R2R action mapping with mermaid diagram

## Testing
- `pre-commit run --files context_chat_backend/backends/r2r.py logger_config.yaml docs/ccbe_r2r_mapping.md`
- `ruff check context_chat_backend/backends/r2r.py`
- `pyright context_chat_backend/backends/r2r.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acae7128bc832a809a8715af0b5c6d