### PR TITLE
fix: avoid deleting documents when hash matches

### DIFF
--- a/docs/ccbe_r2r_mapping.md
+++ b/docs/ccbe_r2r_mapping.md
@@ -5,7 +5,9 @@ graph TD
     LS[PUT /loadSources] --> EC[ensure_collections]
     EC -->|GET /v3/collections| RC1[(list collections)]
     EC -->|POST /v3/collections| RC2[(create collection)]
-    LS --> UD[upsert_document] -->|POST /v3/documents| RU[(upsert document)]
+    LS --> UD[upsert_document]
+    UD -->|POST /v3/documents| RU[(upload document)]
+    UD -->|PUT /v3/documents/{id}/metadata| UM[(update metadata)]
 
     UA[POST /updateAccess] --> UAa[update_access]
     UAa -->|POST/DELETE /v3/collections/{cid}/documents/{doc}| RA[(update collection membership)]
@@ -24,7 +26,7 @@ graph TD
 
 ## Endpoint narratives
 
-- **`PUT /loadSources`** first ensures per-user collections then uploads each document. The controller resolves user IDs and metadata before calling `ensure_collections` and `upsert_document`【F:context_chat_backend/controller.py†L523-L590】. These backend calls translate to listing or creating collections【F:context_chat_backend/backends/r2r.py†L134-L166】 and posting documents to R2R with hash and metadata checks【F:context_chat_backend/backends/r2r.py†L208-L254】.
+- **`PUT /loadSources`** first ensures per-user collections then uploads each document. The controller resolves user IDs and metadata before calling `ensure_collections` and `upsert_document`【F:context_chat_backend/controller.py†L523-L590】. These backend calls translate to listing or creating collections【F:context_chat_backend/backends/r2r.py†L134-L166】 and posting or updating documents with server-side hash checks and metadata updates【F:context_chat_backend/backends/r2r.py†L179-L267】.
 - **`POST /updateAccessDeclarative`** synchronizes document membership for a set of users. CCBE invokes `decl_update_access`【F:context_chat_backend/controller.py†L334-L356】 which lists existing document collections and issues POST/DELETE requests to adjust membership【F:context_chat_backend/backends/r2r.py†L346-L369】.
 - **`POST /updateAccess`** grants or revokes access for users. The controller delegates to `update_access`【F:context_chat_backend/controller.py†L369-L399】 which maps to R2R collection membership operations【F:context_chat_backend/backends/r2r.py†L320-L339】.
 - **`POST /deleteSources`** removes documents by ID. CCBE calls `delete_document` for each identifier【F:context_chat_backend/controller.py†L443-L467】 which issues `DELETE /v3/documents/{id}` in R2R【F:context_chat_backend/backends/r2r.py†L307-L312】.
@@ -32,5 +34,5 @@ graph TD
 - **`POST /query`** and **`POST /docSearch`** forward search requests to R2R. Both endpoints call `search` on the backend【F:context_chat_backend/controller.py†L727-L743】【F:context_chat_backend/controller.py†L768-L778】 which translates into `POST /v3/retrieval/search`【F:context_chat_backend/backends/r2r.py†L372-L390】.
 
 ## References
-- R2R document upsert performs server-side hash comparisons to skip unchanged files【F:context_chat_backend/backends/r2r.py†L179-L195】【F:context_chat_backend/backends/r2r.py†L208-L254】.
+- R2R document upsert performs server-side hash comparisons and updates metadata in place when hashes match【F:context_chat_backend/backends/r2r.py†L179-L267】.
 - Access control modifications operate through collection-document membership changes【F:context_chat_backend/backends/r2r.py†L320-L369】.


### PR DESCRIPTION
## Summary
- use metadata_filter to look up documents by hash
- update existing documents' metadata and collection memberships instead of deleting when hashes match
- document metadata update in CCBE ↔️ R2R mapping

## Testing
- `pre-commit run --files context_chat_backend/backends/r2r.py tests/test_r2r_upsert_document.py docs/ccbe_r2r_mapping.md`
- `pyright context_chat_backend/backends/r2r.py tests/test_r2r_upsert_document.py`
- `PYTHONPATH=. pytest tests/test_r2r_upsert_document.py`


------
https://chatgpt.com/codex/tasks/task_e_68acc3d02c48832aa5534cb2f7c8b0fa