### PR TITLE
fix(r2r): send metadata as list

### DIFF
--- a/context_chat_backend/backends/r2r.py
+++ b/context_chat_backend/backends/r2r.py
@@ -240,11 +240,14 @@ class R2rBackend(RagBackend):
             )
             if same_hash or same_meta:
                 if em != meta:
+                    meta_list = [
+                        {"key": key, "value": value} for key, value in meta.items()
+                    ]
                     self._request(
                         "PUT",
                         f"documents/{existing['id']}/metadata",
                         action=f"upsert_document:update_metadata:{existing['id']}",
-                        json=meta,
+                        json=meta_list,
                     )
                 current = set(existing.get("collection_ids", []))
                 target = set(collection_ids)


### PR DESCRIPTION
## Summary
- ensure R2R metadata updates use list of key/value objects

## Testing
- `pre-commit run --files context_chat_backend/backends/r2r.py`
- `pyright context_chat_backend/backends/r2r.py`
- `ruff check context_chat_backend/backends/r2r.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'context_chat_backend')*

------
https://chatgpt.com/codex/tasks/task_e_68acca750a34832ab9328089245a9c61