### PR TITLE
Avoid deleting R2R documents still ingesting

### DIFF
--- a/context_chat_backend/backends/r2r.py
+++ b/context_chat_backend/backends/r2r.py
@@ -240,8 +240,9 @@ class R2rBackend(RagBackend):
             em = existing.get("metadata", {})
             same_hash = em.get("sha256") == meta.get("sha256")
             same_meta = (
-                em.get("modified") == meta.get("modified")
-                and em.get("content-length") == meta.get("content-length")
+                str(em.get("modified")) == str(meta.get("modified"))
+                and str(em.get("content-length"))
+                == str(meta.get("content-length"))
             )
             if same_hash or same_meta:
                 if em != meta:
@@ -270,6 +271,10 @@ class R2rBackend(RagBackend):
                         f"collections/{cid}/documents/{existing['id']}",
                         action=f"upsert_document:remove:{existing['id']}:{cid}",
                     )
+                return existing["id"]
+
+            ingestion_status = existing.get("ingestion_status") or existing.get("status")
+            if ingestion_status and ingestion_status != "success":
                 return existing["id"]
 
             # If the title matches but the hash differs, replace the existing document.

--- a/docs/ccbe_r2r_mapping.md
+++ b/docs/ccbe_r2r_mapping.md
@@ -34,5 +34,5 @@ graph TD
 - **`POST /query`** and **`POST /docSearch`** forward search requests to R2R. Both endpoints call `search` on the backend【F:context_chat_backend/controller.py†L727-L743】【F:context_chat_backend/controller.py†L768-L778】 which translates into `POST /v3/retrieval/search`【F:context_chat_backend/backends/r2r.py†L372-L390】.
 
 ## References
-- R2R document upsert performs server-side hash comparisons and updates metadata in place when hashes match【F:context_chat_backend/backends/r2r.py†L179-L267】.
+- R2R document upsert performs server-side hash comparisons, updates metadata in place when hashes match, and skips re-uploading documents that are still ingesting【F:context_chat_backend/backends/r2r.py†L179-L267】.
 - Access control modifications operate through collection-document membership changes【F:context_chat_backend/backends/r2r.py†L320-L369】.


### PR DESCRIPTION
## Summary
- normalize metadata comparison in R2R upsert to avoid mismatches
- skip deleting R2R documents that are still ingesting
- document ingestion skip behaviour and add regression test

## Testing
- `pre-commit run --files context_chat_backend/backends/r2r.py docs/ccbe_r2r_mapping.md tests/test_r2r_upsert_document.py`
- `ruff check context_chat_backend/backends/r2r.py tests/test_r2r_upsert_document.py`
- `pyright context_chat_backend/backends/r2r.py tests/test_r2r_upsert_document.py`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad8e553b84832a90e57cf2da341b17