### PR TITLE
fix: ensure exact title document lookup

### DIFF
--- a/context_chat_backend/backends/r2r.py
+++ b/context_chat_backend/backends/r2r.py
@@ -203,8 +203,8 @@ class R2rBackend(RagBackend):
             "documents",
             action="find_document_by_title",
             params={
-                "metadata_filter": json.dumps({"title": title}),
-                "limit": 10,
+                "metadata_filter": json.dumps({"title": {"eq": title}}),
+                "limit": 1,
             },
         )
         for doc in resp.get("results", []) or []:
@@ -336,8 +336,8 @@ class R2rBackend(RagBackend):
             "documents",
             action="find_document_by_filename",
             params={
-                "metadata_filter": json.dumps({"filename": filename}),
-                "limit": 10,
+                "metadata_filter": json.dumps({"filename": {"eq": filename}}),
+                "limit": 1,
             },
         )
         for doc in resp.get("results", []) or []:

--- a/tests/test_r2r_upsert_document.py
+++ b/tests/test_r2r_upsert_document.py
@@ -179,8 +179,8 @@ def test_find_document_by_title_exact_and_mismatch():
     doc = backend.find_document_by_title("doc.txt")
     assert doc and doc["id"] == "doc1"
     assert calls[0]["params"] == {
-        "metadata_filter": json.dumps({"title": "doc.txt"}),
-        "limit": 10,
+        "metadata_filter": json.dumps({"title": {"eq": "doc.txt"}}),
+        "limit": 1,
     }
 
     def fake_request_mismatch(method, path, *, params=None, **kwargs):


### PR DESCRIPTION
## Summary
- use R2R metadata eq filter for document title and filename lookups
- tighten tests for exact title matches

## Testing
- `pre-commit run --files context_chat_backend/backends/r2r.py tests/test_r2r_upsert_document.py`
- `ruff check context_chat_backend/backends/r2r.py tests/test_r2r_upsert_document.py`
- `pyright context_chat_backend/backends/r2r.py tests/test_r2r_upsert_document.py`
- `PYTHONPATH=. pytest tests/test_r2r_upsert_document.py`


------
https://chatgpt.com/codex/tasks/task_e_68ada65522d4832aac26d5f098d2e3bf