### PR TITLE
Fix document lookup filters for R2R backend

### DIFF
--- a/context_chat_backend/backends/r2r.py
+++ b/context_chat_backend/backends/r2r.py
@@ -197,7 +197,10 @@ class R2rBackend(RagBackend):
             "GET",
             "documents",
             action="find_document_by_hash",
-            params={"metadata_filter": json.dumps({"sha256": sha256}), "limit": 1},
+            params={
+                "filters": json.dumps({"metadata.sha256": {"$eq": sha256}}),
+                "limit": 1,
+            },
         )
         results = resp.get("results", [])
         return results[0] if results else None
@@ -211,7 +214,7 @@ class R2rBackend(RagBackend):
             "documents",
             action="find_document_by_title",
             params={
-                "metadata_filter": json.dumps({"title": {"eq": title}}),
+                "filters": json.dumps({"metadata.title": {"$eq": title}}),
                 "limit": 1,
             },
         )
@@ -380,7 +383,7 @@ class R2rBackend(RagBackend):
             "documents",
             action="find_document_by_filename",
             params={
-                "metadata_filter": json.dumps({"filename": {"eq": filename}}),
+                "filters": json.dumps({"metadata.filename": {"$eq": filename}}),
                 "limit": 1,
             },
         )

--- a/tests/test_r2r_upsert_document.py
+++ b/tests/test_r2r_upsert_document.py
@@ -156,7 +156,7 @@ def test_find_document_by_hash_returns_none():
 
     assert backend.find_document_by_hash("abc") is None
     assert captured["params"] == {
-        "metadata_filter": json.dumps({"sha256": "abc"}),
+        "filters": json.dumps({"metadata.sha256": {"$eq": "abc"}}),
         "limit": 1,
     }
 
@@ -179,7 +179,7 @@ def test_find_document_by_title_exact_and_mismatch():
     doc = backend.find_document_by_title("doc.txt")
     assert doc and doc["id"] == "doc1"
     assert calls[0]["params"] == {
-        "metadata_filter": json.dumps({"title": {"eq": "doc.txt"}}),
+        "filters": json.dumps({"metadata.title": {"$eq": "doc.txt"}}),
         "limit": 1,
     }
 


### PR DESCRIPTION
## Summary
- query R2R documents using `filters` param for hash, title, and filename
- update tests for new filter syntax

## Testing
- `ruff check context_chat_backend/backends/r2r.py tests/test_r2r_upsert_document.py`
- `pyright context_chat_backend/backends/r2r.py tests/test_r2r_upsert_document.py`
- `pre-commit run --files context_chat_backend/backends/r2r.py tests/test_r2r_upsert_document.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'context_chat_backend')*


------
https://chatgpt.com/codex/tasks/task_e_68b22e78cea0832aa0fe2eca295d1f7a