### PR TITLE
Handle required query field in R2R hash search

### DIFF
--- a/context_chat_backend/backends/r2r.py
+++ b/context_chat_backend/backends/r2r.py
@@ -198,6 +198,7 @@ class R2rBackend(RagBackend):
             "documents/search",
             action="find_document_by_hash",
             json={
+                "query": "",
                 "filters": {"metadata.sha256": {"$eq": sha256}},
                 "limit": 1,
             },

--- a/docs/ccbe_r2r_mapping.md
+++ b/docs/ccbe_r2r_mapping.md
@@ -35,5 +35,5 @@ graph TD
 
 ## References
 
-- R2R document upsert performs a server-side hash comparison to avoid re-uploading unchanged files, updating metadata in place when hashes match and skipping documents that are still ingesting【F:context_chat_backend/backends/r2r.py†L245-L334】【F:context_chat_backend/backends/r2r.py†L187-L209】.
+- R2R document upsert performs a server-side hash comparison by issuing `POST /v3/documents/search` with an empty query and metadata filter to avoid re-uploading unchanged files, updating metadata in place when hashes match and skipping documents that are still ingesting【F:context_chat_backend/backends/r2r.py†L246-L336】【F:context_chat_backend/backends/r2r.py†L187-L205】.
 - Access control modifications operate through collection-document membership changes【F:context_chat_backend/backends/r2r.py†L421-L469】.


### PR DESCRIPTION
## Summary
- include an empty `query` when searching documents by hash
- document the hash search API change in the R2R mapping

## Testing
- `pre-commit run --files context_chat_backend/backends/r2r.py docs/ccbe_r2r_mapping.md`
- `ruff check context_chat_backend/backends/r2r.py`
- `pyright context_chat_backend/backends/r2r.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'context_chat_backend')*

------
https://chatgpt.com/codex/tasks/task_e_68b30d6dbac0832abb12d795f58aac16