### PR TITLE
Fix R2R dedup search payload

### DIFF
--- a/context_chat_backend/backends/r2r.py
+++ b/context_chat_backend/backends/r2r.py
@@ -199,8 +199,11 @@ class R2rBackend(RagBackend):
                 action="find_document_by_hash",
                 json={
                     "query": "",
-                    "filters": {"metadata.sha256": {"$eq": sha256}},
-                    "limit": 1,
+                    "search_mode": "advanced",
+                    "search_settings": {
+                        "filters": {"metadata.sha256": {"$eq": sha256}},
+                        "limit": 1,
+                    },
                 },
             )
         except httpx.TimeoutException:

--- a/docs/ccbe_r2r_mapping.md
+++ b/docs/ccbe_r2r_mapping.md
@@ -35,5 +35,5 @@ graph TD
 
 ## References
 
-- R2R document upsert performs a server-side hash comparison by issuing `POST /v3/documents/search` with an empty query and metadata filter to avoid re-uploading unchanged files, updating metadata in place when hashes match and skipping documents that are still ingesting【F:context_chat_backend/backends/r2r.py†L246-L336】【F:context_chat_backend/backends/r2r.py†L187-L205】.
+- R2R document upsert performs a server-side hash comparison by issuing `POST /v3/documents/search` with an empty query, `search_mode` set to `advanced`, and `search_settings` containing a metadata hash filter and limit to avoid re-uploading unchanged files, updating metadata in place when hashes match and skipping documents that are still ingesting【F:context_chat_backend/backends/r2r.py†L246-L336】【F:context_chat_backend/backends/r2r.py†L187-L205】.
 - Access control modifications operate through collection-document membership changes【F:context_chat_backend/backends/r2r.py†L421-L469】.

--- a/r2rdocs.txt
+++ b/r2rdocs.txt
@@ -7864,7 +7864,12 @@ curl -X POST https://api.sciphi.ai/v3/documents/search \
      -H "Authorization: Bearer <token>" \
      -H "Content-Type: application/json" \
      -d '{
-  "query": "query"
+  "query": "",
+  "search_mode": "advanced",
+  "search_settings": {
+    "filters": {"metadata.sha256": {"$eq": "<hash>"}},
+    "limit": 1
+  }
 }'
 ```
 
@@ -7874,7 +7879,12 @@ curl -X POST https://api.sciphi.ai/v3/documents/search \
      -H "Authorization: Bearer <token>" \
      -H "Content-Type: application/json" \
      -d '{
-  "query": "string"
+  "query": "",
+  "search_mode": "advanced",
+  "search_settings": {
+    "filters": {"metadata.sha256": {"$eq": "<hash>"}},
+    "limit": 1
+  }
 }'
 ```
 

--- a/tests/test_r2r_upsert_document.py
+++ b/tests/test_r2r_upsert_document.py
@@ -160,7 +160,14 @@ def test_find_document_by_hash_returns_none():
     assert calls and calls[0] == (
         "POST",
         "documents/search",
-        {"query": "", "filters": {"metadata.sha256": {"$eq": "abc"}}, "limit": 1},
+        {
+            "query": "",
+            "search_mode": "advanced",
+            "search_settings": {
+                "filters": {"metadata.sha256": {"$eq": "abc"}},
+                "limit": 1,
+            },
+        },
     )
 
 


### PR DESCRIPTION
## Summary
- include search mode and settings when searching documents by hash
- document correct cURL for dedup search

## Testing
- `pre-commit run --files context_chat_backend/backends/r2r.py tests/test_r2r_upsert_document.py docs/ccbe_r2r_mapping.md r2rdocs.txt`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b316334118832aa0c64beb4687c128