### PR TITLE
Use retrieval search for hash dedup

### DIFF
--- a/docs/ccbe_r2r_mapping.md
+++ b/docs/ccbe_r2r_mapping.md
@@ -26,7 +26,7 @@ graph TD
 
 ## Endpoint narratives
 
-- **`PUT /loadSources`** first ensures per-user collections then uploads each document. The controller resolves user IDs and metadata before calling `ensure_collections` and `upsert_document`【F:context_chat_backend/controller.py†L523-L590】. These backend calls translate to listing or creating collections【F:context_chat_backend/backends/r2r.py†L142-L174】 and posting or updating documents with server-side hash checks and metadata updates while using a custom ingestion mode【F:context_chat_backend/backends/r2r.py†L245-L378】.
+- **`PUT /loadSources`** first ensures per-user collections then uploads each document. The controller resolves user IDs and metadata before calling `ensure_collections` and `upsert_document`【F:context_chat_backend/controller.py†L523-L590】. These backend calls translate to listing or creating collections【F:context_chat_backend/backends/r2r.py†L142-L174】 and posting or updating documents with server-side hash checks and metadata updates while using a custom ingestion mode【F:context_chat_backend/backends/r2r.py†L264-L379】.
 - **`POST /updateAccessDeclarative`** synchronizes document membership for a set of users. CCBE invokes `decl_update_access`【F:context_chat_backend/controller.py†L334-L356】 which lists existing document collections and issues POST/DELETE requests to adjust membership【F:context_chat_backend/backends/r2r.py†L446-L469】.
 - **`POST /updateAccess`** grants or revokes access for users. The controller delegates to `update_access`【F:context_chat_backend/controller.py†L369-L399】 which maps to R2R collection membership operations【F:context_chat_backend/backends/r2r.py†L421-L441】.
 - **`POST /deleteSources`** removes documents by ID. CCBE calls `delete_document` for each identifier【F:context_chat_backend/controller.py†L443-L467】 which issues `DELETE /v3/documents/{id}` in R2R【F:context_chat_backend/backends/r2r.py†L403-L412】.
@@ -35,5 +35,5 @@ graph TD
 
 ## References
 
-- R2R document upsert performs a server-side hash comparison by issuing `POST /v3/documents/search` with an empty query, `search_mode` set to `advanced`, and `search_settings` containing a metadata hash filter and limit to avoid re-uploading unchanged files, updating metadata in place when hashes match and skipping documents that are still ingesting【F:context_chat_backend/backends/r2r.py†L246-L336】【F:context_chat_backend/backends/r2r.py†L187-L205】.
+- R2R document upsert performs a server-side hash comparison by issuing `POST /v3/retrieval/search` with a wildcard query (`*`), `search_mode` set to `basic`, and `search_settings` containing a metadata hash filter and limit to avoid re-uploading unchanged files, updating metadata in place when hashes match and skipping documents that are still ingesting【F:context_chat_backend/backends/r2r.py†L264-L334】【F:context_chat_backend/backends/r2r.py†L187-L228】.
 - Access control modifications operate through collection-document membership changes【F:context_chat_backend/backends/r2r.py†L421-L469】.

--- a/tests/test_r2r_upsert_document.py
+++ b/tests/test_r2r_upsert_document.py
@@ -152,17 +152,17 @@ def test_find_document_by_hash_returns_none():
 
     def fake_request(method, path, *, json=None, **kwargs):
         calls.append((method, path, json))
-        return {"results": []}
+        return {"results": {"chunk_search_results": []}}
 
     backend._request = fake_request  # type: ignore[attr-defined]
 
     assert backend.find_document_by_hash("abc") is None
     assert calls and calls[0] == (
         "POST",
-        "documents/search",
+        "retrieval/search",
         {
-            "query": "",
-            "search_mode": "advanced",
+            "query": "*",
+            "search_mode": "basic",
             "search_settings": {
                 "filters": {"metadata.sha256": {"$eq": "abc"}},
                 "limit": 1,
@@ -176,9 +176,14 @@ def test_find_document_by_hash_returns_match():
 
     def fake_request(method, path, *, json=None, **kwargs):
         return {
-            "results": [
-                {"id": "doc1", "metadata": {"sha256": "abc"}},
-            ]
+            "results": {
+                "chunk_search_results": [
+                    {
+                        "document_id": "doc1",
+                        "metadata": {"sha256": "abc"},
+                    }
+                ]
+            }
         }
 
     backend._request = fake_request  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- switch hash-based deduplication to `/v3/retrieval/search` with a wildcard query
- document the new dedup search flow in R2R mapping
- update unit tests for revised search payload and results

## Testing
- `pre-commit run --files context_chat_backend/backends/r2r.py tests/test_r2r_upsert_document.py docs/ccbe_r2r_mapping.md`
- `pyright context_chat_backend/backends/r2r.py tests/test_r2r_upsert_document.py`
- `PYTHONPATH=. pytest tests/test_r2r_upsert_document.py`


------
https://chatgpt.com/codex/tasks/task_e_68b32e1ada78832abfd202cb3bfef933