### PR TITLE
fix: filter R2R search by user collection

### DIFF
--- a/context_chat_backend/controller.py
+++ b/context_chat_backend/controller.py
@@ -741,6 +741,7 @@ def _(query: Query, request: Request) -> LLMOutput:
             scope_type=query.scopeType,
             scope_list=query.scopeList,
         )
+        logger.debug("backend search hits", extra={"hits": hits})
         docs = [Document(page_content=h.get("page_content", ""), metadata=h.get("metadata", {})) for h in hits]
         if len(docs) == 0:
             raise ContextException("No documents retrieved, please index a few documents first")
@@ -777,13 +778,16 @@ def _(query: Query, request: Request) -> list[SearchResult]:
             scope_type=query.scopeType,
             scope_list=query.scopeList,
         )
-        return [
+        logger.debug("docSearch hits", extra={"hits": hits})
+        results: list[SearchResult] = [
             {
                 "source_id": h.get("metadata", {}).get("source", ""),
                 "title": h.get("metadata", {}).get("title", ""),
             }
             for h in hits
         ]
+        logger.debug("docSearch results", extra={"results": results})
+        return results
 
     # useContext from Query is not used here
     return exec_in_proc(

--- a/docs/ccbe_r2r_mapping.md
+++ b/docs/ccbe_r2r_mapping.md
@@ -31,7 +31,7 @@ graph TD
 - **`POST /updateAccess`** grants or revokes access for users. The controller delegates to `update_access`【F:context_chat_backend/controller.py†L369-L399】 which maps to R2R collection membership operations【F:context_chat_backend/backends/r2r.py†L421-L441】.
 - **`POST /deleteSources`** removes documents by ID. CCBE calls `delete_document` for each identifier【F:context_chat_backend/controller.py†L443-L467】 which issues `DELETE /v3/documents/{id}` in R2R【F:context_chat_backend/backends/r2r.py†L403-L412】.
 - **`POST /countIndexedDocuments`** reports document counts. When using R2R, it simply lists documents and returns the length【F:context_chat_backend/controller.py†L511-L517】【F:context_chat_backend/backends/r2r.py†L178-L185】.
-- **`POST /query`** and **`POST /docSearch`** forward search requests to R2R. Both endpoints call `search` on the backend【F:context_chat_backend/controller.py†L727-L743】【F:context_chat_backend/controller.py†L768-L778】 which translates into `POST /v3/retrieval/search`【F:context_chat_backend/backends/r2r.py†L472-L520】.
+- **`POST /query`** and **`POST /docSearch`** forward search requests to R2R. Both endpoints call `search` on the backend【F:context_chat_backend/controller.py†L727-L743】【F:context_chat_backend/controller.py†L768-L778】 which translates into `POST /v3/retrieval/search` filtered by the user's collection ID【F:context_chat_backend/backends/r2r.py†L506-L540】.
 
 ## References
 


### PR DESCRIPTION
## Summary
- filter R2R search calls by user collection ID
- document search interaction mapping with collection filtering
- log R2R search payloads and hits for easier tracing

## Testing
- `pre-commit run --files context_chat_backend/backends/r2r.py context_chat_backend/controller.py`
- `pyright context_chat_backend/backends/r2r.py context_chat_backend/controller.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b42f9fa7d8832abc0770508569c1fd