### PR TITLE
Log docSearch requests and update endpoint references

### DIFF
--- a/docs/ccbe_r2r_mapping.md
+++ b/docs/ccbe_r2r_mapping.md
@@ -31,7 +31,7 @@ graph TD
 - **`POST /updateAccess`** grants or revokes access for users. The controller delegates to `update_access`【F:context_chat_backend/controller.py†L369-L399】 which maps to R2R collection membership operations【F:context_chat_backend/backends/r2r.py†L421-L441】.
 - **`POST /deleteSources`** removes documents by ID. CCBE calls `delete_document` for each identifier【F:context_chat_backend/controller.py†L443-L467】 which issues `DELETE /v3/documents/{id}` in R2R【F:context_chat_backend/backends/r2r.py†L403-L412】.
 - **`POST /countIndexedDocuments`** reports document counts. When using R2R, it simply lists documents and returns the length【F:context_chat_backend/controller.py†L511-L517】【F:context_chat_backend/backends/r2r.py†L178-L185】.
-- **`POST /query`** and **`POST /docSearch`** forward search requests to R2R. Both endpoints call `search` on the backend【F:context_chat_backend/controller.py†L727-L743】【F:context_chat_backend/controller.py†L768-L778】 which translates into `POST /v3/retrieval/search` filtered by the user's collection ID【F:context_chat_backend/backends/r2r.py†L506-L540】.
+- **`POST /query`** and **`POST /docSearch`** forward search requests to R2R. Both endpoints call `search` on the backend【F:context_chat_backend/controller.py†L727-L743】【F:context_chat_backend/controller.py†L769-L782】 which translates into `POST /v3/retrieval/search` filtered by the user's collection ID【F:context_chat_backend/backends/r2r.py†L506-L540】.
 
 ## References
 

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -15,5 +15,5 @@
 | POST | `/countIndexedDocuments` | Count indexed documents across providers or via backend【F:context_chat_backend/controller.py†L511-L519】 |
 | PUT | `/loadSources` | Ingest documents for users, ensuring collection mapping and deduplication【F:context_chat_backend/controller.py†L523-L590】 |
 | POST | `/query` | Perform question answering, optionally retrieving context from backend【F:context_chat_backend/controller.py†L727-L765】 |
-| POST | `/docSearch` | Search for documents matching a query without invoking the LLM【F:context_chat_backend/controller.py†L768-L799】 |
+| POST | `/docSearch` | Search for documents matching a query without invoking the LLM【F:context_chat_backend/controller.py†L769-L804】 |
 | GET | `/downloadLogs` | Download zipped server logs for debugging【F:context_chat_backend/controller.py†L802-L811】 |


### PR DESCRIPTION
## Summary
- log incoming `/docSearch` requests so Nextcloud interactions are captured
- always record and return document search results regardless of backend
- update endpoint documentation to reflect new line numbers

## Testing
- `pre-commit run --files context_chat_backend/controller.py docs/endpoints.md docs/ccbe_r2r_mapping.md`
- `ruff check -v context_chat_backend/controller.py docs/endpoints.md docs/ccbe_r2r_mapping.md`
- `pyright context_chat_backend/controller.py`
- `PYTHONPATH=$PWD pytest` *(fails: missing async plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68b448d492b4832abf89eadc1acc3187