### PR TITLE
Return camelCase sourceId in docSearch results

### DIFF
--- a/context_chat_backend/chain/context.py
+++ b/context_chat_backend/chain/context.py
@@ -79,7 +79,7 @@ def do_doc_search(
 
 		sources_cache[source_id] = None
 		results.append(SearchResult(
-			source_id=source_id,
+			sourceId=source_id,
 			title=doc.metadata.get('title', ''),
 		))
 

--- a/context_chat_backend/chain/types.py
+++ b/context_chat_backend/chain/types.py
@@ -40,5 +40,5 @@ class LLMOutput(TypedDict):
 
 
 class SearchResult(TypedDict):
-	source_id: str
-	title: str
+        sourceId: str
+        title: str

--- a/context_chat_backend/controller.py
+++ b/context_chat_backend/controller.py
@@ -782,7 +782,7 @@ def _(query: Query, request: Request) -> list[SearchResult]:
         logger.debug("docSearch hits", extra={"hits": hits})
         results: list[SearchResult] = [
             {
-                "source_id": h.get("metadata", {}).get("source", ""),
+                "sourceId": h.get("metadata", {}).get("source", ""),
                 "title": h.get("metadata", {}).get("title", ""),
             }
             for h in hits

--- a/context_chat_backend/startup_tests.py
+++ b/context_chat_backend/startup_tests.py
@@ -99,7 +99,7 @@ async def _verify_deletion_with_retry(
                 return True
             missing = True
             for r in results:
-                sid = r.get("source_id")
+                sid = r.get("sourceId")
                 title = r.get("title")
                 if deleted_source_id and sid == deleted_source_id:
                     missing = False

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -15,5 +15,5 @@
 | POST | `/countIndexedDocuments` | Count indexed documents across providers or via backend【F:context_chat_backend/controller.py†L511-L519】 |
 | PUT | `/loadSources` | Ingest documents for users, ensuring collection mapping and deduplication【F:context_chat_backend/controller.py†L523-L590】 |
 | POST | `/query` | Perform question answering, optionally retrieving context from backend【F:context_chat_backend/controller.py†L727-L765】 |
-| POST | `/docSearch` | Search for documents matching a query without invoking the LLM【F:context_chat_backend/controller.py†L769-L804】 |
+| POST | `/docSearch` | Search for documents matching a query without invoking the LLM; returns `[{"sourceId", "title"}]`【F:context_chat_backend/controller.py†L769-L804】 |
 | GET | `/downloadLogs` | Download zipped server logs for debugging【F:context_chat_backend/controller.py†L802-L811】 |


### PR DESCRIPTION
## Summary
- align docSearch responses with Nextcloud client expectations by returning `sourceId`
- update SearchResult type and tests accordingly
- document docSearch response shape

## Testing
- `python -m pre_commit run --files context_chat_backend/chain/types.py context_chat_backend/chain/context.py context_chat_backend/controller.py context_chat_backend/startup_tests.py docs/endpoints.md`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4571e2404832ab41bd9297155cd2f