### PR TITLE
Use R2R RAG endpoint for searches

### DIFF
--- a/CCBE-R2R_Endpoint_map.txt
+++ b/CCBE-R2R_Endpoint_map.txt
@@ -14,5 +14,5 @@ POST /deleteUser -> DELETE /users/{id}
 POST /countIndexedDocuments -> GET /documents
 PUT /loadSources -> POST /documents
 POST /query -> POST /retrieval/rag
-POST /docSearch -> POST /retrieval/search
+POST /docSearch -> POST /retrieval/rag
 GET /downloadLogs -> GET /logs/viewer

--- a/context_chat_backend/backends/r2r.py
+++ b/context_chat_backend/backends/r2r.py
@@ -518,18 +518,18 @@ class R2rBackend(RagBackend):
         logger.debug("R2R search payload: %s", json.dumps(payload, sort_keys=True))
         try:
             resp = self._request(
-                "POST", "retrieval/search", action="/v3/retrieval/search", json=payload
+                "POST", "retrieval/rag", action="/v3/retrieval/rag", json=payload
             )
         except httpx.HTTPError as exc:
             logger.warning("search request failed", extra={"error": str(exc)})
             return []
-        results = resp.get("results", {})
+        rag_results = resp.get("results", {})
+        results = rag_results.get("search_results") if isinstance(rag_results, dict) else {}
 
-        # Newer R2R versions wrap chunk hits inside
-        # ``results.chunk_search_results`` while older builds
-        # returned a bare list.  Support both shapes and ignore
-        # any unexpected primitives to keep the startup check
-        # resilient across versions.
+        # R2R may return chunk hits either directly in ``results``
+        # or nested under ``results.search_results``. Support both
+        # shapes and ignore unexpected primitives to keep the startup
+        # check resilient across versions.
         if isinstance(results, list):
             hits: Sequence[Any] = results
         elif isinstance(results, dict):

--- a/context_chat_backend/controller.py
+++ b/context_chat_backend/controller.py
@@ -755,7 +755,7 @@ def _(query: Query, request: Request) -> LLMOutput:
         ).strip()
 
         unique_sources: list[str] = list(
-            {cast(str, d.metadata["source"]) for d in docs if d.metadata.get("source")}
+            {cast(str, d.metadata["title"]) for d in docs if d.metadata.get("title")}
         )
         return LLMOutput(output=output, sources=unique_sources)
 
@@ -782,7 +782,7 @@ def _(query: Query, request: Request) -> list[SearchResult]:
         logger.debug("docSearch hits", extra={"hits": hits})
         results: list[SearchResult] = [
             {
-                "sourceId": h.get("metadata", {}).get("source", ""),
+                "sourceId": h.get("metadata", {}).get("title", ""),
                 "title": h.get("metadata", {}).get("title", ""),
             }
             for h in hits

--- a/docs/ccbe_r2r_mapping.md
+++ b/docs/ccbe_r2r_mapping.md
@@ -20,7 +20,7 @@ graph TD
 
     CID[POST /countIndexedDocuments] --> LD[list_documents] -->|GET /v3/documents| RD[(list documents)]
 
-    Q[POST /query] --> SR[search] -->|POST /v3/retrieval/search| RS[(search)]
+    Q[POST /query] --> SR[search] -->|POST /v3/retrieval/rag| RS[(rag)]
     DOCS[POST /docSearch] --> SR
 ```
 
@@ -31,7 +31,7 @@ graph TD
 - **`POST /updateAccess`** grants or revokes access for users. The controller delegates to `update_access`【F:context_chat_backend/controller.py†L369-L399】 which maps to R2R collection membership operations【F:context_chat_backend/backends/r2r.py†L421-L441】.
 - **`POST /deleteSources`** removes documents by ID. CCBE calls `delete_document` for each identifier【F:context_chat_backend/controller.py†L443-L467】 which issues `DELETE /v3/documents/{id}` in R2R【F:context_chat_backend/backends/r2r.py†L403-L412】.
 - **`POST /countIndexedDocuments`** reports document counts. When using R2R, it simply lists documents and returns the length【F:context_chat_backend/controller.py†L511-L517】【F:context_chat_backend/backends/r2r.py†L178-L185】.
-- **`POST /query`** and **`POST /docSearch`** forward search requests to R2R. Both endpoints call `search` on the backend【F:context_chat_backend/controller.py†L727-L743】【F:context_chat_backend/controller.py†L769-L782】 which translates into `POST /v3/retrieval/search` filtered by the user's collection ID【F:context_chat_backend/backends/r2r.py†L506-L540】.
+- **`POST /query`** and **`POST /docSearch`** forward search requests to R2R. Both endpoints call `search` on the backend【F:context_chat_backend/controller.py†L737-L743】【F:context_chat_backend/controller.py†L775-L781】 which translates into `POST /v3/retrieval/rag` filtered by the user's collection ID【F:context_chat_backend/backends/r2r.py†L506-L552】.
 
 ## References
 


### PR DESCRIPTION
## Summary
- switch R2R backend search to `/v3/retrieval/rag`
- return document paths for query and docSearch results
- update R2R mapping docs

## Testing
- `pre-commit run --files context_chat_backend/backends/r2r.py context_chat_backend/controller.py docs/ccbe_r2r_mapping.md CCBE-R2R_Endpoint_map.txt`
- `PYTHONPATH=. pytest` *(failed: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68b45fea7c30832abbce959eacbfe48c