### PR TITLE
feat(r2r): make HTTP timeout configurable

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -135,6 +135,7 @@ class RagBackend:
 ```
 RAG_BACKEND=r2r
 R2R_BASE_URL=http://127.0.0.1:7272
+R2R_HTTP_TIMEOUT=300
 ```
 
 **Lessons baked in**

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ RAG_BACKEND=builtin
 # Optional: R2R Graph RAG
 # RAG_BACKEND=r2r
 # R2R_BASE_URL=http://127.0.0.1:7272
+# R2R_HTTP_TIMEOUT=300           # optional, in seconds
 # R2R_API_KEY=your_api_key_here  # sent as X-API-Key
 # R2R_API_TOKEN=your_token_here  # optional bearer token
 
@@ -65,6 +66,7 @@ RAG_BACKEND=builtin
    ```bash
    RAG_BACKEND=r2r
    R2R_BASE_URL=http://127.0.0.1:7272
+   # R2R_HTTP_TIMEOUT=300
    # R2R_API_KEY=your_api_key_here  # sent as X-API-Key
    # R2R_API_TOKEN=your_token_here
    ```

--- a/context_chat_backend/backends/r2r.py
+++ b/context_chat_backend/backends/r2r.py
@@ -45,9 +45,15 @@ class R2rBackend(RagBackend):
             headers["X-API-Key"] = api_key
         if token:
             headers["Authorization"] = f"Bearer {token}"
-        # Increase timeout to accommodate slow retrieval searches and other
-        # potentially long-running operations.
-        self._client = httpx.Client(base_url=base, timeout=60.0, headers=headers)
+
+        # Allow slow retrieval searches by using a generous default timeout.
+        # ``R2R_HTTP_TIMEOUT`` (seconds) can override the default of 300.
+        timeout_str = os.getenv("R2R_HTTP_TIMEOUT", "300")
+        try:
+            timeout = float(timeout_str)
+        except ValueError:
+            timeout = 300.0
+        self._client = httpx.Client(base_url=base, timeout=timeout, headers=headers)
 
         # Echo the curl command for lifecycle checks and easier debugging.
         curl_parts = ["curl", "-i"]

--- a/example.env
+++ b/example.env
@@ -33,6 +33,9 @@ RAG_BACKEND=r2r
 # Example: http://r2r:7272 when R2R runs as a Docker service on the same network.
 R2R_BASE_URL=http://127.0.0.1:7272
 
+# Optional timeout in seconds for R2R HTTP requests
+# R2R_HTTP_TIMEOUT=300
+
 # Optional credentials for authenticated R2R instances
 # R2R_API_KEY=your_api_key_here       # sent as X-API-Key
 # R2R_API_TOKEN=your_token_here       # sent as Authorization: Bearer


### PR DESCRIPTION
## Summary
- allow overriding R2R HTTP timeout via `R2R_HTTP_TIMEOUT`
- document new variable in README, example.env, and PRD

## Testing
- `pre-commit run --files PRD.md README.md context_chat_backend/backends/r2r.py example.env`
- `pyright`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b465e0f4b8832abb2d6aef9aabf185