### PR TITLE
R2R adapter: caller-side backpressure and retryable ingestion + docs

### DIFF
--- a/context_chat_backend/backends/errors.py
+++ b/context_chat_backend/backends/errors.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+class RetryableBackendBusy(Exception):
+    """Signal that the backend is temporarily busy and the client should retry.
+
+    Optionally carries a small payload that response middleware can use to
+    craft endpoint-specific retry responses (e.g., sources_to_retry for
+    /loadSources).
+    """
+
+    def __init__(self, message: str = "", payload: Mapping[str, Any] | None = None):
+        super().__init__(message)
+        self.payload: dict[str, Any] = dict(payload or {})

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -13,7 +13,7 @@
 | POST | `/deleteProvider` | Delete documents belonging to a provider for all users【F:context_chat_backend/controller.py†L479-L492】 |
 | POST | `/deleteUser` | Remove all documents and access entries for a user【F:context_chat_backend/controller.py†L495-L508】 |
 | POST | `/countIndexedDocuments` | Count indexed documents across providers or via backend【F:context_chat_backend/controller.py†L511-L519】 |
-| PUT | `/loadSources` | Ingest documents for users, ensuring collection mapping and deduplication【F:context_chat_backend/controller.py†L523-L590】 |
+| PUT | `/loadSources` | Ingest documents for users, ensuring collection mapping and deduplication【F:context_chat_backend/controller.py†L523-L590】. When `RAG_BACKEND=r2r` and the upstream is overloaded, responds `503` with header `cc-retry: true` (retryable). |
 | POST | `/query` | Perform question answering, optionally retrieving context from backend【F:context_chat_backend/controller.py†L727-L765】 |
 | POST | `/docSearch` | Search for documents matching a query without invoking the LLM; returns `[{"sourceId", "title"}]`【F:context_chat_backend/controller.py†L769-L804】 |
 | GET | `/downloadLogs` | Download zipped server logs for debugging【F:context_chat_backend/controller.py†L802-L811】 |


### PR DESCRIPTION
- Add RetryableBackendBusy with payload support and central handler mapping to:
  - 200 {loaded_sources, sources_to_retry} for /loadSources
  - 503 cc-retry (+Retry-After) for other routes
- R2R backend: raise retryable for backpressure/timeout/502–504, include source id
- Add lightweight caller-side saturation metrics & in-flight gating
- Simplify env defaults; disable Rabbit probe + RTT gate by default
- Update README: rationale, collections model, endpoint mapping, backpressure strategy
- R2R-Integration.md: add caller-side saturation and tunables